### PR TITLE
fix: gravity without weight and gravity_factor_pixelated scaled correctly

### DIFF
--- a/src/core/ecs/world.rs
+++ b/src/core/ecs/world.rs
@@ -208,10 +208,10 @@ impl World {
             ) {
                 if rigid_body.body_type == BodyType::Dynamic {
                     if transform.position.strategy == Strategy::Pixelated {
-                        let gravity_factor_pixelated: f32 = gravity.value * render_state.physical_size.unwrap().height as f32;
-                        velocity.y += gravity_factor_pixelated * rigid_body.mass * rigid_body.friction * delta;
+                        let gravity_factor_pixelated: f32 = gravity.value * (render_state.physical_size.unwrap().height/2) as f32;
+                        velocity.y += gravity_factor_pixelated * rigid_body.friction * delta;
                     } else {
-                        velocity.y -= gravity.value * rigid_body.mass * rigid_body.friction * delta;
+                        velocity.y -= gravity.value * rigid_body.friction * delta;
                     }
                     let new_y: f32 = transform.position.y + velocity.y * delta;
                     transform.set_position_y(render_state, new_y);


### PR DESCRIPTION
- Removed the weight on gravity calculation.
- Adjusted the gravity_factor_pixelated calculation, dividing the screen height by two. It was giving pixelated entities double acceleration compared to normalized entities. Resulting on the following:

https://github.com/user-attachments/assets/93a730a4-d3f4-44b2-acb5-f974bc9c2a9a

This happens because the calculation uses **render_state.physical_size.unwrap().height**, which is the entire height of the screen. However, in the normalized field, the entire height is equivalent to two normalized units (+1 to 0 and 0 to -1):
![image](https://github.com/user-attachments/assets/ef06bc77-a4db-4d0b-8efa-0511195af118)

To fix this, all we need to do is half the **render_state.physical_size.unwrap().height** value, then we get one normalized unit:
![image](https://github.com/user-attachments/assets/16252a48-8a40-4ce9-9c1b-d10f95e977a4)


